### PR TITLE
文字コードをASCIIからUTF-8に変更

### DIFF
--- a/visionAPI_test.py
+++ b/visionAPI_test.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 #python label_detection.py (APIキー) (画像ファイルのパス)
 #api_key AIzaSyCYzlittDbDrELqOMGn77-LYLiuplMnvgA
 
@@ -10,7 +13,7 @@ ENDPOINT_URL = 'https://vision.googleapis.com/v1/images:annotate'
 
 if __name__ == '__main__':
     image_filenames = argv[1:]
-    
+
     img_requests = []
     for imgname in image_filenames:
         with open(imgname, 'rb') as f:


### PR DESCRIPTION
visionAPI_test.pyのプログラムの文字コード設定をASCIIからUTF-8に変更
変更しないと、ASCIIコードだと以下のエラーがでる

SyntaxError: Non-ASCII character '\xe5' in file voice_test.py on line 21, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details